### PR TITLE
Added param to live image for cache

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -290,7 +290,7 @@
 
     socket.on('image:live', function (data) {
       el.src = '';
-      el.src = './live.jpg';
+      el.src = './live.jpg?t='+new Date().getTime();
     });
 
     socket.on('connections:count', function (data) {


### PR DESCRIPTION
It's better to add a param to the img src so every browser can update the live image without get it from the cache.
